### PR TITLE
chore: move the sessionId to the root of the event

### DIFF
--- a/Runtime/Core/EventTracker.cs
+++ b/Runtime/Core/EventTracker.cs
@@ -268,6 +268,7 @@ namespace LoopKit.Core
                 groupType = groupType ?? "organization",
                 properties = properties ?? new Dictionary<string, object>(),
                 anonymousId = _sessionManager.GetAnonymousId(),
+                sessionId = _sessionManager.GetSessionId(),
                 timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                 system = CreateSystemInfo(),
                 userId = ExtractUserId(userContext),
@@ -284,7 +285,6 @@ namespace LoopKit.Core
             return new SystemInfo
             {
                 sdk = new SDKInfo { name = "unity", version = Utils.VersionInfo.VERSION },
-                sessionId = _sessionManager.GetSessionId(),
                 context = new ContextInfo
                 {
                     scene = new SceneInfo

--- a/Runtime/Types/LoopKitTypes.cs
+++ b/Runtime/Types/LoopKitTypes.cs
@@ -128,7 +128,6 @@ namespace LoopKit
     public class SystemInfo
     {
         public SDKInfo sdk = new SDKInfo();
-        public string sessionId;
         public ContextInfo context = new ContextInfo();
     }
 
@@ -200,6 +199,7 @@ namespace LoopKit
     public abstract class BaseEvent
     {
         public string anonymousId;
+        public string sessionId;
         public string timestamp;
         public string userId;
         public SystemInfo system = new SystemInfo();

--- a/Runtime/Utils/VersionInfo.cs
+++ b/Runtime/Utils/VersionInfo.cs
@@ -12,7 +12,7 @@ namespace LoopKit.Utils
         /// <summary>
         /// Current SDK version - update this when releasing new versions
         /// </summary>
-        public const string VERSION = "1.0.3";
+        public const string VERSION = "1.0.4";
 
         /// <summary>
         /// Package name for Unity Package Manager


### PR DESCRIPTION
### Background

The `sessionId` is a critical identifier, used for associating many events together. By moving the property to the root of the event, we greatly simplify down stream usage/consumption. 

### Summary
* Move `sessionId` to the root of the event.